### PR TITLE
Fix variants not working

### DIFF
--- a/animate/animate.js
+++ b/animate/animate.js
@@ -275,6 +275,9 @@ module.exports = function (settings = {}, variants = ['responsive']) {
             '.fadeOutUpBig': {
                 animationName: 'fadeOutUpBig'
             },
+        }, variants(variants));
+
+        addUtilities({
             '@keyframes bounce': keyframes.keyframeBounce,
             '@keyframes flash': keyframes.keyframeFlash,
             '@keyframes pulse': keyframes.keyframePulse,
@@ -353,6 +356,6 @@ module.exports = function (settings = {}, variants = ['responsive']) {
             '@keyframes fadeOutRightBig': keyframesFadeOut.keyframeFadeOutRightBig,
             '@keyframes fadeOutUp': keyframesFadeOut.keyframeFadeOutUp,
             '@keyframes fadeOutUpBig': keyframesFadeOut.keyframeFadeOutUpBig
-        }, variants(variants))
+        });
     };
 };

--- a/animate/animate.js
+++ b/animate/animate.js
@@ -14,7 +14,7 @@ const keyframesFadeIn = require('./keyframes/fadeIn');
 const keyframesFadeOut = require('./keyframes/fadeOut');
 
 module.exports = function (settings = {}, variants = ['responsive']) {
-    return function ({ e, addUtilities, variants }) {
+    return function ({ e, addUtilities }) {
 
         // set fallback if speed not defined
         const animatedSpeed = settings.settings.animatedSpeed ? settings.settings.animatedSpeed : 1000;
@@ -275,7 +275,7 @@ module.exports = function (settings = {}, variants = ['responsive']) {
             '.fadeOutUpBig': {
                 animationName: 'fadeOutUpBig'
             },
-        }, variants(variants));
+        }, variants);
 
         addUtilities({
             '@keyframes bounce': keyframes.keyframeBounce,

--- a/animate/animate.js
+++ b/animate/animate.js
@@ -13,16 +13,16 @@ const keyframesSlideOut = require('./keyframes/slideOut');
 const keyframesFadeIn = require('./keyframes/fadeIn');
 const keyframesFadeOut = require('./keyframes/fadeOut');
 
-module.exports = function (settings = {}, variants = ['responsive']) {
+module.exports = function ({ settings = {}, variants = ['responsive'] }) {
     return function ({ e, addUtilities }) {
 
         // set fallback if speed not defined
-        const animatedSpeed = settings.settings.animatedSpeed ? settings.settings.animatedSpeed : 1000;
-        const heartBeatSpeed = settings.settings.heartBeatSpeed ? settings.settings.heartBeatSpeed : 1000;
-        const hingeSpeed = settings.settings.hingeSpeed ? settings.settings.hingeSpeed : 2000;
-        const bounceInSpeed = settings.settings.bounceInSpeed ? settings.settings.bounceInSpeed : 750;
-        const bounceOutSpeed = settings.settings.bounceOutSpeed ? settings.settings.bounceOutSpeed : 750;
-        const opacity = settings.settings.opacity ? settings.settings.opacity : 1;
+        const animatedSpeed = settings.animatedSpeed ? settings.animatedSpeed : 1000;
+        const heartBeatSpeed = settings.heartBeatSpeed ? settings.heartBeatSpeed : 1000;
+        const hingeSpeed = settings.hingeSpeed ? settings.hingeSpeed : 2000;
+        const bounceInSpeed = settings.bounceInSpeed ? settings.bounceInSpeed : 750;
+        const bounceOutSpeed = settings.bounceOutSpeed ? settings.bounceOutSpeed : 750;
+        const opacity = settings.opacity ? settings.opacity : 1;
 
         addUtilities({
             '.animated': {


### PR DESCRIPTION
I noticed that variants weren't working, so I made a few changes and now they work.

1. Since tailwind can't generate variants for @keyframe rules, we extract those utilities to a second call to addUtilities.
2. According to the README, the way to specify which variants to generate is passing an array as a 'variants' element on the passed object, so we don't need to call the `variants()` function that tailwind provides.
3. Finally, we accept only one object argument, that has the settings and variants, instead of two arguments. This is mostly done to avoid modifications to the README and to avoid breaking changes. Before, if you used the plugin as is indicated in the README, the variants element in the object would be ignored, and only the default `['responsive']` argument would be used, but that one was _also_ ignored, because of shadowing by the destructured `variant` helper function by tailwind