### PR TITLE
Fixing the #12 !important flag breaking the plugin

### DIFF
--- a/animate/animate.js
+++ b/animate/animate.js
@@ -306,7 +306,7 @@ module.exports = function ({ settings = {}, variants = ['responsive'] }) {
             '.fadeOutUpBig': {
                 animationName: 'fadeOutUpBig'
             },
-        }, variants);
+        }, { variants, respectImportant: false });
 
         addUtilities({
             '@keyframes bounce': keyframes.keyframeBounce,
@@ -387,6 +387,6 @@ module.exports = function ({ settings = {}, variants = ['responsive'] }) {
             '@keyframes fadeOutRightBig': keyframesFadeOut.keyframeFadeOutRightBig,
             '@keyframes fadeOutUp': keyframesFadeOut.keyframeFadeOutUp,
             '@keyframes fadeOutUpBig': keyframesFadeOut.keyframeFadeOutUpBig
-        });
+        }, { respectImportant: false });
     };
 };


### PR DESCRIPTION
When used with important: true (enabled) it breaks the animation keyframes. Fixed by overriding the flag with addUtilities respectImportant set to false, also fixed the variants - it should be placed in object - not directly after the utilities.