### PR TITLE
Add missing scaleY from bounce animation

### DIFF
--- a/src/keyframes/keyframes.js
+++ b/src/keyframes/keyframes.js
@@ -5,14 +5,18 @@ const keyframeBounce = {
     },
     '40%, 43%': {
         animationTimingFunction: 'cubic-bezier(0.755, 0.05, 0.855, 0.06)',
-        transform: 'translate3d(0, -30px, 0)'
+        transform: 'translate3d(0, -30px, 0) scaleY(1.1)'
     },
     '70%': {
         animationTimingFunction: 'cubic-bezier(0.755, 0.05, 0.855, 0.06)',
-        transform: 'translate3d(0, -15px, 0)'
+        transform: 'translate3d(0, -15px, 0) scaleY(1.05)'
+    },
+    '80%': {
+        animationTimingFunction: 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+        transform: 'translate3d(0, 0, 0) scaleY(0.95)'
     },
     '90%': {
-        transform: 'translate3d(0, -4px, 0)'
+        transform: 'translate3d(0, -4px, 0) scaleY(1.02)'
     }
 };
 


### PR DESCRIPTION
`scaleY` transform in the original [animate.css bounce](https://github.com/animate-css/animate.css/blob/main/source/attention_seekers/bounce.css) was missing, making the animation a bit stiff. This change tries to fix that.